### PR TITLE
Added multi-wallet support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ $promise = $litecoind->requestAsync(
 $promise->wait();
 ```
 
+## Multi-Wallet RPC
+You can use `wallet($name)` function to do a [Multi-Wallet RPC call](https://github.com/litecoin-project/litecoin/blob/v0.15.0.1rc1/doc/release-notes-litecoin.md#multi-wallet-support):
+```php
+/**
+ * Get wallet2.dat balance.
+ */
+$balance = $litecoind->wallet('wallet2.dat')->getbalance();
+
+$balance->get(); // 0.10000000
+```
+
 ## License
 
 This product is distributed under MIT license.

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,6 +19,13 @@ class Client
     protected $client = null;
 
     /**
+     * URL path.
+     *
+     * @var string
+     */
+    protected $path = '/';
+
+    /**
      * JSON-RPC Id.
      *
      * @var int
@@ -98,6 +105,20 @@ class Client
     }
 
     /**
+     * Sets wallet for multi-wallet rpc request.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function wallet($name)
+    {
+        $this->path = "/wallet/$name";
+
+        return $this;
+    }
+
+    /**
      * Makes request to Litecoin Core.
      *
      * @param string $method
@@ -114,7 +135,7 @@ class Client
                 'id'     => $this->rpcId++,
             ];
 
-            $response = $this->client->request('POST', '/', ['json' => $json]);
+            $response = $this->client->request('POST', $this->path, ['json' => $json]);
 
             if ($response->hasError()) {
                 // throw exception on error
@@ -162,7 +183,7 @@ class Client
         ];
 
         $promise = $this->client
-            ->requestAsync('POST', '/', ['json' => $json]);
+            ->requestAsync('POST', $this->path, ['json' => $json]);
 
         $promise->then(
             function (ResponseInterface $response) use ($onFullfiled) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     ];
 
     /**
+     * Balance response.
+     *
+     * @var float
+     */
+    protected static $balanceResponse = 0.1;
+
+    /**
      * Get error 500 message.
      *
      * @return string
@@ -94,11 +101,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return \GuzzleHttp\Client
      */
-    protected function mockGuzzle(array $queue = [])
+    protected function mockGuzzle(array $queue = [], &$container = [])
     {
         $handler = $this->litecoind->getConfig('handler');
 
         if ($handler) {
+            $history = \GuzzleHttp\Middleware::history($container);
+            $handler->push($history);
             $handler->setHandler(new MockHandler($queue));
         }
 
@@ -118,6 +127,24 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $json = json_encode([
             'result' => self::$getBlockResponse,
+            'error'  => null,
+            'id'     => 0,
+        ]);
+
+        return new Response($code, [], $json);
+    }
+
+    /**
+     * Get getbalance command response.
+     *
+     * @param int $code
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function getBalanceResponse($code = 200)
+    {
+        $json = json_encode([
+            'result' => self::$balanceResponse,
             'error'  => null,
             'id'     => 0,
         ]);


### PR DESCRIPTION
Implemented ability to perform multi-wallet RPC calls and added tests for it.
Example: `$litecoind->wallet('wallet1.dat')->getbalance();`

See: [Documentation](https://github.com/litecoin-project/litecoin/blob/v0.15.0.1rc1/doc/release-notes-litecoin.md#multi-wallet-support) and https://github.com/litecoin-project/litecoin/issues/458